### PR TITLE
Configuration Color Palette

### DIFF
--- a/portfolio-project-matching-app/tailwind.config.js
+++ b/portfolio-project-matching-app/tailwind.config.js
@@ -9,8 +9,19 @@ module.exports = {
         'xs': '420px',
         ...defaultTheme.screens,
       },
+      colors: {
+        'custom-cool-extraDark': '#001219',
+        'custom-cool-dark': '#005f73',
+        'custom-cool-med': '#0a9396',
+        'custom-cool-light': '#94d2bd',
+        'custom-cool-extraLight': '#e9d8a6',
+        'custom-warm-extraLight': '#ee9b00',
+        'custom-warm-light': '#ca6702',
+        'custom-warm-med': '#bb3e03',
+        'custom-warm-dark': '#ae2012',
+        'custom-warm-darkExtra': '#9b2226'
+      }
     },
-    // extend: {},
   },
   variants: {
     extend: {},


### PR DESCRIPTION
Quick and easy addition of custom colors using color-agnostic names:
- Decided to categorize colors as warm and dark.
- colors scale from extraDark to extraLight.
- `custom` keyword appended to the beginning of each new color s.t. the full palette pulls up while coding (rather than the developer needing to look at the `.config` file).
- Hopefully, we will be able to swap out color palettes easily if we fall out of favor with the current choice.
![image](https://user-images.githubusercontent.com/59572911/137565851-1c37be4a-ff34-4b7b-a3d6-7ab266a3a9d7.png)
