### PR TITLE
Hot fix browse projects route

### DIFF
--- a/portfolio-project-matching-app/components/FilterButtons.js
+++ b/portfolio-project-matching-app/components/FilterButtons.js
@@ -39,8 +39,8 @@ const FilterButtons = ({ category, choices, onClick }) => {
             <div>
                 {selectedChoices.map((choice) => {
                     return (
-                        <div className='py-1 pr-2'>
-                            <Button key={choice.id} type='btnWarning' text={choice.name} onClick={() => removeFilter(choice)} />
+                        <div key={choice.id} className='py-1 pr-2'>
+                            <Button type='btnWarning' text={choice.name} onClick={() => removeFilter(choice)} />
                         </div>
                     )
                 })}
@@ -51,8 +51,8 @@ const FilterButtons = ({ category, choices, onClick }) => {
             <div className='flex flex-wrap'>
                 {availableChoices.map((choice) => {
                     return (
-                        <div className='py-1 pr-2'>
-                            <Button key={choice.id} type='btnGeneral' text={choice.name} onClick={() => addFilter(choice)} />
+                        <div key={choice.id} className='py-1 pr-2'>
+                            <Button type='btnGeneral' text={choice.name} onClick={() => addFilter(choice)} />
                         </div>
                     )
                 })}

--- a/portfolio-project-matching-app/components/Nav.js
+++ b/portfolio-project-matching-app/components/Nav.js
@@ -23,7 +23,7 @@ const Nav = () => {
                 </li>
                 <li className="justify-self-end">
                     {   path === "/myProfile" ?
-                        <Link href="/" passHref>
+                        <Link href="/browseProjects" passHref>
                             {/* Link's child must take an href, so Button must be wrapped with <a> tags */}
                             <a>
                             <Button text="Browse" isLink={true} addClassName="bg-white m-2"/>

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -19,8 +19,8 @@ const ProjectCard = ({ project }) => {
             <div className='flex flex-wrap'>
                 {project.technologies.map((technology) => {
                     return (
-                        <div className='py-1 pr-2'>
-                            <Button key={technology.id} text={technology.name}/>
+                        <div key={technology.id} className='py-1 pr-2'>
+                            <Button text={technology.name}/>
                         </div>
                 )
                 })}


### PR DESCRIPTION
This is a quick hot fix branch to address the Nav route for `browseProjects` page.

I also moved the `key` prop to the parent element in a few places where the `map()` method was used. I think it was able to remove the annoying console warning. 