### PR TITLE
Enhancement `browseProjects` page `ProjectCard` content reduction

### DIFF
--- a/portfolio-project-matching-app/backend/dao.js
+++ b/portfolio-project-matching-app/backend/dao.js
@@ -38,7 +38,9 @@ import {
     getTechnologiesByUserId,
     getUserById,
 } from '../backend/daoUser'
-import { DocumentReference } from '@firebase/firestore'
+import { Project } from '../models/Project'
+import { User } from '../models/User'
+import { Technology } from '../models/Technology'
 
 /*
     CREATE
@@ -224,6 +226,51 @@ const getPayload = (coll, id1, id2) => {
 
 // see daoProject.js, daoUser.js, and daoTechnology.js
 
+const readAllDocs = async (coll) => {
+    /*
+    DESCRIPTION:    retrieves all documents in the specified collection and
+                    returns an array of custom objects. Note, the associations
+                    will not be populated in the objects.
+
+    INPUT:          coll (string): collection to get documents from
+
+    RETURN:         array of custom objects
+    */
+    // get collection snapshot
+    const collSnap = await getCollectionSnapshot(coll);
+    // handle case of invalid collection name
+    if (collSnap.empty) {
+        console.log(`Collection '${coll}' does not exist.`);
+        return -1;
+    }
+    // handle case of collection passed that the function can't handle
+    if (coll !== 'projects' && coll !== 'users' && coll !== 'technologies') {
+        console.log(`Invalid collection: please use 'projects', 'users' or 'technologies'.`);
+        return -1;
+    }
+    // handle case of valid collection name
+    else {
+        // loop through documents in the snapshot, adding objects to array
+        const objects = [];
+        for (const doc of collSnap.docs) {
+            // handle case of 'projects' collection
+            if (coll === 'projects') {
+                objects.push(Project.fromDocSnapshot(doc.id, doc));
+            }
+            // handle case of 'users' collection
+            else if (coll === 'users') {
+                objects.push(User.fromDocSnapshot(doc.id, doc));
+            }
+            // handle case of 'technologies collection
+            else if (coll === 'technologies') {
+                objects.push(Technology.fromDocSnapshot(doc.id, doc));
+            }
+        }
+        // return populated array to calling function
+        return objects;
+    }
+}
+
 /*
     UPDATE
 */
@@ -381,6 +428,7 @@ export {
     getTechnologyById,
     getUserById,
     getUsersByProjectId,
+    readAllDocs,
     // UPDATE
     updateDoc,
     // DELETE

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -17,8 +17,7 @@ const ProjectCard = ({ project }) => {
                 <p className='text-xl font-medium'>{project.name}</p>
             </div>
             <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
-            {/* Commented out, but leaving in just in case we decide to add this back */}
-            {/* <div className='flex flex-wrap'>
+            <div className='flex flex-wrap'>
                 {project.technologies.map((technology) => {
                     return (
                         <div key={technology.id} className='py-1 pr-2'>
@@ -26,7 +25,7 @@ const ProjectCard = ({ project }) => {
                         </div>
                 )
                 })}
-            </div> */}
+            </div>
             <div className=''>
                 <p>{project.description}</p>
             </div>

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -26,8 +26,10 @@ const ProjectCard = ({ project }) => {
                 )
                 })}
             </div>
-            <div className='truncate'>
-                {project.description}
+            <div className=''>
+                <p className='line-clamp-3 lg:line-clamp-2 xl:line-clamp-1'>
+                    {project.description}
+                </p>
             </div>
             <div className='mt-2 flex flex-wrap'>
                 <div className='self-center'>

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -17,7 +17,8 @@ const ProjectCard = ({ project }) => {
                 <p className='text-xl font-medium'>{project.name}</p>
             </div>
             <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
-            <div className='flex flex-wrap'>
+            {/* Commented out, but leaving in just in case we decide to add this back */}
+            {/* <div className='flex flex-wrap'>
                 {project.technologies.map((technology) => {
                     return (
                         <div key={technology.id} className='py-1 pr-2'>
@@ -25,24 +26,27 @@ const ProjectCard = ({ project }) => {
                         </div>
                 )
                 })}
-            </div>
+            </div> */}
             <div className=''>
                 <p>{project.description}</p>
             </div>
-            <div className='mt-4'>
-                <p>{project.census} out of {project.capacity} ({project.capacity - project.census} positions left)</p>
+            <div className='mt-2 flex flex-wrap'>
+                <div className='self-center'>
+                    {project.census} out of {project.capacity} ({project.capacity - project.census} positions left)
+                    </div>
+                <div className='p-1'>
+                    <Button text='join' type='btnGeneral' />
+                </div>
             </div>
             <div className='flex flex-wrap'>
-                {project.users.map((user) => {
+                {/* Commented out, but leaving in just in case we decide to add this back */}
+                {/* {project.users.map((user) => {
                     return (
                     <div key={user.id} className='py-1 pr-2'>
                         <UserIcon imgPath='/../public/user.ico' username={user.username} />
                     </div>
                     )
-                })}
-                <div className='p-1'>
-                    <Button text='join' type='btnGeneral' />
-                </div>
+                })} */}
             </div>
             <div className='inline'>
                 <h3 className='py-1 inline'>{project.likes} Likes</h3>

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -26,8 +26,8 @@ const ProjectCard = ({ project }) => {
                 )
                 })}
             </div>
-            <div className=''>
-                <p>{project.description}</p>
+            <div className='truncate'>
+                {project.description}
             </div>
             <div className='mt-2 flex flex-wrap'>
                 <div className='self-center'>

--- a/portfolio-project-matching-app/package-lock.json
+++ b/portfolio-project-matching-app/package-lock.json
@@ -2243,6 +2243,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@tailwindcss/line-clamp": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.2.2.tgz",
+      "integrity": "sha512-NgA4Ds+/eCiO+6O3SooRsfJ8m7M2+QvNvHwOjBQq7FIYoWwAV4I4Wu4fjHeuO9Yi6p47ceHUKEGGEBh0ozQodg=="
+    },
     "@testing-library/dom": {
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.0.tgz",

--- a/portfolio-project-matching-app/package.json
+++ b/portfolio-project-matching-app/package.json
@@ -10,6 +10,7 @@
     "test": "jest --watch"
   },
   "dependencies": {
+    "@tailwindcss/line-clamp": "^0.2.2",
     "firebase": "^9.1.0",
     "next": "11.1.2",
     "react": "17.0.2",

--- a/portfolio-project-matching-app/pages/browseProjects.js
+++ b/portfolio-project-matching-app/pages/browseProjects.js
@@ -34,11 +34,11 @@ const browseProjects = () => {
         // tracks whether component mounted, cleanup will assign false
         let isMounted = true
         // get projects and set state if component mounted
-        readAllDocs('projects').then((projects) => {
+        getAllProjects().then((projects) => {
             if (isMounted) setVisibleProjects(projects)
         })
         // get technologies and set state if component mounted
-        readAllDocs('technologies').then((technologies) => {
+        getAllTechnologies().then((technologies) => {
             if (isMounted) setAllTechnologies(technologies)
         })
         // cleanup function to assign false to isMounted

--- a/portfolio-project-matching-app/pages/browseProjects.js
+++ b/portfolio-project-matching-app/pages/browseProjects.js
@@ -2,7 +2,11 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 // backend
-import { getAllProjects, getAllTechnologies } from '../backend/dao'
+import {
+    getAllProjects,
+    getAllTechnologies,
+    readAllDocs,
+} from '../backend/dao'
 // component
 import Button from '../components/Button'
 import FilterButtons from '../components/FilterButtons'
@@ -30,11 +34,11 @@ const browseProjects = () => {
         // tracks whether component mounted, cleanup will assign false
         let isMounted = true
         // get projects and set state if component mounted
-        getAllProjects().then((projects) => {
+        readAllDocs('projects').then((projects) => {
             if (isMounted) setVisibleProjects(projects)
         })
         // get technologies and set state if component mounted
-        getAllTechnologies().then((technologies) => {
+        readAllDocs('technologies').then((technologies) => {
             if (isMounted) setAllTechnologies(technologies)
         })
         // cleanup function to assign false to isMounted

--- a/portfolio-project-matching-app/pages/test_dao.js
+++ b/portfolio-project-matching-app/pages/test_dao.js
@@ -13,6 +13,7 @@ import {
     deleteProjectsUsersDoc,
     deleteUserDoc,
     getProjectById,
+    readAllDocs,
     updateDoc,
     updateProject,
 } from '../backend/dao'
@@ -98,10 +99,10 @@ const test_createProject = () => {
         // const userId = 'PdJa7Nq3LJCbEOFxA2Vj';
         // await deleteAssociation('projects_users', projectId, userId); 
 
-        const coll = 'users';
-        const id = 'invalid id';
-        const myVal = await deleteDoc(coll, id);
-        console.log(`deleteDoc(${coll}, ${id}): ${myVal}`);
+        const coll = 'technologies';
+        const docs = await readAllDocs(coll);
+        console.log(`All '${coll}': `, docs);
+
 
     }
 

--- a/portfolio-project-matching-app/tailwind.config.js
+++ b/portfolio-project-matching-app/tailwind.config.js
@@ -26,5 +26,8 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    // helps with ProjectCard truncation on different screen sizes
+    require('@tailwindcss/line-clamp'),
+  ],
 }


### PR DESCRIPTION
Per our discussion during the standup meeting earlier today, I've removed the associations from the `ProjectCard` content. Moreover, I created a function in `dao.js` named `readAllDocs()` designed to pull all projects, users, or technologies and populate an array of objects to return to the calling function. Note, these will only populate "surface level" fields. In other words, it will not query the relationship/association tables to populate all associated documents e.g., when calling `readAllDocs('projects')`, one would not expect to have the `technologies` or `users` fields populated. This greatly reduces the time required for `browseProjects` to load.

11/09/2021 Edit: Switched back to full query and decided to add technologies back into `ProjectCard` to maintain filtering by technology capabilities.

11/10/2021 Edit: Truncated `ProjectCard` project description s.t. it only takes up a variable number of lines depending on screen size. E.g., 3 lines at small screen size, 2 at medium, etc.

SMALL
![image](https://user-images.githubusercontent.com/59572911/141146912-b1eab0cb-dce7-4456-ac46-8b99ce705d5a.png)

MEDIUM
![image](https://user-images.githubusercontent.com/59572911/141147029-78fa9520-04f7-42d0-98f5-37d1a5127f17.png)
