### PR TITLE
Bug `dao.js` closing bracket

### DIFF
--- a/portfolio-project-matching-app/backend/dao.js
+++ b/portfolio-project-matching-app/backend/dao.js
@@ -365,6 +365,7 @@ const collectionIsValid = async (coll) => {
                     is valid
     */
     return coll === 'projects' || coll === 'users' || coll === 'technologies';
+}
 
 const readQuerySnapshotById = async (coll, field, id) => {
     /*


### PR DESCRIPTION
When I merged conflicts between `enhancement-daoCleanup` and `Sprint-5`, I mistakenly erased a closing bracket. Reverting appeared to open a big can of worms due to the aforementioned merge. Here is the quick fix.