### PR TITLE
Feature `myApplications` Page

### DIFF
--- a/portfolio-project-matching-app/backend/dao.js
+++ b/portfolio-project-matching-app/backend/dao.js
@@ -365,6 +365,7 @@ const collectionIsValid = async (coll) => {
                     is valid
     */
     return coll === 'projects' || coll === 'users' || coll === 'technologies';
+}
 
 const readQuerySnapshotById = async (coll, field, id) => {
     /*

--- a/portfolio-project-matching-app/backend/dao.js
+++ b/portfolio-project-matching-app/backend/dao.js
@@ -549,7 +549,7 @@ const updateDoc = async (coll, id, payload) => {
     else {
         // update document and indicate success to user
         const newDocSnap = await updateDocument(coll, id, payload);
-        console.log(`Updated project '${newDocSnap.id}'`);
+        console.log(`Updated '${coll}' document '${newDocSnap.id}'`);
         return newDocSnap;
     }
 }

--- a/portfolio-project-matching-app/backend/dao.js
+++ b/portfolio-project-matching-app/backend/dao.js
@@ -392,7 +392,8 @@ const readApplicationsById = async (field, id) => {
 
     INPUT:          field (string): document field to be compared against id
 
-                    id (string) : document ID of document being updated
+                    id (string) : document ID of document being compared
+                    against field
 
     RETURN:         array of Application objects
     */
@@ -421,6 +422,35 @@ const readApplicationsById = async (field, id) => {
         }
         // return array of Application objects to calling function
         return applications;
+    }
+}
+
+const readApplicationByApplicationId = async (id) => {
+    /*
+    DESCRIPTION:    retrieves application document by application document id
+
+    INPUT:          id (string) : document ID of desired application
+
+    RETURN:         Application object
+    */
+    // get snapshot for invalid input handling
+    const docSnap = await getDocSnapshotById('applications', id);
+    if (!docSnap.exists()) {
+        console.log(`Invalid id: 'applications' does not have document id '${id}'`);
+        return -1;
+    }
+    // handle case of valid field
+    else {
+        // build "base" Application object
+        const app = Application.fromDocSnapshot(docSnap.id, docSnap);
+        // populate project, user, and owner properties with applicable objects
+        [app.project, app.user, app.owner] = await Promise.all([
+            getShallowProjectById(app.projectId),
+            getShallowUserById(app.userId),
+            getShallowUserById(app.ownerId)
+        ])
+        // return array of Application objects to calling function
+        return app;
     }
 }
 
@@ -730,6 +760,7 @@ export {
     getUserById,
     getUsersByProjectId,
     readAllDocs,
+    readApplicationByApplicationId,
     readApplicationsById,
     // UPDATE
     updateDoc,

--- a/portfolio-project-matching-app/backend/daoProject.js
+++ b/portfolio-project-matching-app/backend/daoProject.js
@@ -238,6 +238,31 @@ const getProjectById = async (projectId) => {
     }
 }
 
+const getShallowProjectById = async (projectId) => {
+    /*
+    DESCRIPTION:    retrieves project data for specified project document ID.
+                    The owner, users, and technologies will be null
+
+    INPUT:          desired project document ID in string format
+
+    RETURN:         project object containing data associated with project
+                    document ID passed as argument
+    */
+    // get project doc snapshot and use to initialize project object
+    const projectSnap = await getDocSnapshotById('projects', projectId);
+    
+    // handle case where projectId is valid
+    if (projectSnap.exists()){
+        const project = Project.fromDocSnapshot(projectSnap.id, projectSnap);
+        return project;
+    }
+    // handle case where projectId is invalid
+    else {
+        console.log(`invalid projectId: '${projectId}' does not exist`);
+        return -1;
+    }
+}
+
 const getOwnerByUserId = async (userId) => {
     /*
     DESCRIPTION:    retrieves owner User object associated with specified
@@ -470,6 +495,7 @@ export {
     getAllProjects,
     getOwnerByUserId,
     getProjectById,
+    getShallowProjectById,
     getTechnologiesByProjectId,
     getUsersByProjectId,
     // UPDATE

--- a/portfolio-project-matching-app/backend/daoUser.js
+++ b/portfolio-project-matching-app/backend/daoUser.js
@@ -170,6 +170,29 @@ const getUserById = async (userId) => {
     }
 }
 
+const getShallowUserById = async (userId) => {
+    /*
+    DESCRIPTION:    retrieves user data for specified user document ID.
+                    projects and technologies will remain null
+
+    INPUT:          desired user document ID in string format
+
+    RETURN:         user object containing data associated with user
+                    document ID passed as argument
+    */
+    // get user doc snapshot and use to initialize user object
+    const userSnap = await getDocSnapshotById('users', userId);
+
+    // handle case where user does not exist
+    if (!userSnap.exists()) {
+        console.log(`invalid id: '${userId}' does not exist in 'users'`);
+        return -1;
+    }else{
+        const user = User.fromDocSnapshot(userSnap.id, userSnap);
+        return user;
+    }
+}
+
 const getProjectsByUserId = async (userId) => {
     /*
     DESCRIPTION:    retrieves projects associated with specified user ID
@@ -288,6 +311,7 @@ export {
     getAllUsers,
     getDeepProjectsByUserId,
     getProjectsByUserId,
+    getShallowUserById,
     getTechnologiesByUserId,
     getUserById,
     // DELETE

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -1,92 +1,112 @@
 // library
 import { useState, useEffect } from 'react'
 // backend
-import { updateDoc, createAssociation } from '../backend/dao'
+import { updateDoc, createAssociation, readApplicationByApplicationId } from '../backend/dao'
 // component
 import Button from '../components/Button'
 import UserIcon from '../components/UserIcon'
+// model
+import { Application } from '../models/Application'
 
 
-const ApplicationCard = ({ app, isOutgoing }) => {
+const ApplicationCard = ({ appId, isOutgoing }) => {
     // state to force re-rendering of application data on reject, approve, etc
     // probably better way to do this, but wanted to avoid re-querying the
     // db from the parent and re-rendering the entire list
-    const [appToUse, setAppToUse] = useState(app)
+    const [app, setApp] = useState()
 
     const onAction = async (response) => {
-        console.log('appToUse at beginning of onAction: ', appToUse)                // **** DEBUG DELETE ME ****
         // build payload to update application document
         const payload = {open: false, response: response}
         // handle case of re-opened application
         if (response === 'Pending') {
             payload.open = true
         }
-        // update Firebase document
-        await updateDoc('applications', appToUse.id, payload)
+        // update Firebase document and get updated Application object
+        await updateDoc('applications', app.id, payload)
+        const updatedApp = await readApplicationByApplicationId(app.id)
         // handle case of approved application
         if (response === 'Approved') {
-            await createAssociation('projects_users', appToUse.project_id, appToUse.user_id)
+            createAssociation('projects_users', app.project_id, appToUse.user_id)
         }
-        const updatedApp = appToUse
-        updatedApp.response = payload.response
-        updatedApp.open = payload.open
-        console.log('appToUse: ', appToUse)
-        console.log('updatedApp:', updatedApp)
-        setAppToUse(updatedApp)
-        console.log('appToUse: ', appToUse)
+        setApp(updatedApp)
     }
+
+    useEffect(() => {
+        // tracks whether component mounted, cleanup will assign false
+        let isMounted = true
+        // get Application object and set state if component mounted
+        readApplicationByApplicationId(appId).then((app) => {
+            if (isMounted) setApp(app)
+        })
+        // cleanup function to assign false to isMounted
+        return function cleanup() {
+            isMounted = false
+        }
+    }, [])
 
     return (
         <div className='p-2 w-full h-full border-2 border-gray-400 rounded-md'>
-            <div className='w-full'>
-                <p className='text-xl font-medium'>{appToUse.project.name}</p>
-            </div>
-            <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
-            <div className='pt-2'>
-                {
-                    isOutgoing ?
-                        <div>
-                            Project Owner:{'  '}
-                            <UserIcon username={appToUse.owner.username} />
-                        </div>
-                    :
-                        <div>
-                            Applicant:{'  '}
-                            <UserIcon username={appToUse.user.username}/>
-                        </div>
-                }
-            </div>
-            <div className='pt-2'>
-                Response: {appToUse.response}
-            </div>
-            <div className='pt-2'>
-                Status: {appToUse.open ? 'Open' : 'Closed'}
-            </div>
-            <div className='pt-8'>
-                {
-                    !appToUse.open && appToUse.response === 'Cancelled' ?
+            {
+                // handle case where application fetched and state set
+                app ?
                     <div>
-                        <Button text='Re-Open Application' type='btnGeneral' onClick={() => onAction('Pending')}/>
-                    </div>
-                    :
-                    !appToUse.open ?
-                    <div></div>
-                    :
-                    isOutgoing ?
-                    <div>
-                        <Button text='Cancel Application' type='btnWarning' onClick={() => onAction('Cancelled')}/>
-                    </div>
-                    :
-                    <div>
-                        <div className='inline pr-2'>
-                            <Button text='Approve' type='btnGeneral' onClick={() => onAction('Approved')}/>
+                        <div className='w-full'>
+                            <p className='text-xl font-medium'>{app.project.name}</p>
                         </div>
-                        <div className='inline'>
-                            <Button text='Reject' type='btnWarning' onClick={() => onAction('Rejected')}/>
+                        <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
+                        <div className='pt-2'>
+                            {
+                                isOutgoing ?
+                                    <div>
+                                        Project Owner:{'  '}
+                                        <UserIcon username={app.owner.username} />
+                                    </div>
+                                :
+                                    <div>
+                                        Applicant:{'  '}
+                                        <UserIcon username={app.user.username}/>
+                                    </div>
+                            }
+                        </div>
+                        <div className='pt-2'>
+                            Response: {app.response}
+                        </div>
+                        <div className='pt-2'>
+                            Status: {app.open ? 'Open' : 'Closed'}
+                        </div>
+                        <div className='pt-8'>
+                            {
+                                !app.open && app.response === 'Cancelled' ?
+                                <div>
+                                    <Button text='Re-Open Application' type='btnGeneral' onClick={() => onAction('Pending')}/>
+                                </div>
+                                :
+                                !app.open ?
+                                <div></div>
+                                :
+                                isOutgoing ?
+                                <div>
+                                    <Button text='Cancel Application' type='btnWarning' onClick={() => onAction('Cancelled')}/>
+                                </div>
+                                :
+                                <div>
+                                    <div className='inline pr-2'>
+                                        <Button text='Approve' type='btnGeneral' onClick={() => onAction('Approved')}/>
+                                    </div>
+                                    <div className='inline'>
+                                        <Button text='Reject' type='btnWarning' onClick={() => onAction('Rejected')}/>
+                                    </div>
+                                </div>
+                            }
                         </div>
                     </div>
-                }
-            </div>
+                // handle case where app is still being fetched and state empty
+                :
+                    <div>
+                    Loading...
+                    </div>
+            }
         </div>
     )
 }

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -5,8 +5,6 @@ import { updateDoc, createAssociation, readApplicationByApplicationId } from '..
 // component
 import Button from '../components/Button'
 import UserIcon from '../components/UserIcon'
-// model
-import { Application } from '../models/Application'
 
 
 const ApplicationCard = ({ appId, isOutgoing }) => {
@@ -27,7 +25,7 @@ const ApplicationCard = ({ appId, isOutgoing }) => {
         const updatedApp = await readApplicationByApplicationId(app.id)
         // handle case of approved application
         if (response === 'Approved') {
-            createAssociation('projects_users', app.project_id, appToUse.user_id)
+            createAssociation('projects_users', app.project_id, app.user_id)
         }
         setApp(updatedApp)
     }

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -1,0 +1,66 @@
+// library
+// component
+import Button from '../components/Button'
+
+
+const ApplicationCard = ({ app, isOutgoing }) => {
+    return (
+        <div className='p-2 w-full h-full border-2 border-gray-400 rounded-md'>
+            <div className='w-full'>
+                <p className='text-xl font-medium'>{app.project.name}</p>
+            </div>
+            <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
+            <div>
+                Project Owner: {app.owner.username}
+            </div>
+            <div>
+                <Button text='Cancel Application' type='btnWarning' onClick={() => {}}/>
+            </div>
+            {/* <div className='flex flex-wrap'>
+                {projectToUse.technologies.map((technology) => {
+                    return (
+                        <div key={technology.id} className='py-1 pr-2'>
+                            <Button text={technology.name}/>
+                        </div>
+                )
+                })}
+            </div>
+            <div className=''>
+                <p className='line-clamp-3 lg:line-clamp-2 xl:line-clamp-1'>
+                    {projectToUse.description}
+                </p>
+            </div>
+            <div className='mt-2 flex flex-wrap'>
+                <div className='self-center'>
+                    {projectToUse.census} out of {projectToUse.capacity} ({projectToUse.capacity - projectToUse.census} positions left)
+                    </div>
+                <div className='p-1'>
+                    <Button text='join' onClick={applyToProject} type='btnGeneral' />
+                </div>
+            </div>
+            <div className='flex flex-wrap'>
+                Commented out, but leaving in just in case we decide to add this back
+                {project.users.map((user) => {
+                    return (
+                    <div key={user.id} className='py-1 pr-2'>
+                        <UserIcon imgPath='/../public/user.ico' username={user.username} />
+                    </div>
+                    )
+                })}
+            </div>
+            <div className='inline'>
+                <h3 className='py-1 inline'>{projectToUse.likes} Likes</h3>
+                <div className='p-1 inline'>
+                    <Button text='Like' onClick={likeProject} type='btnGeneral' />
+                </div>
+            </div>
+            <Link href={`/project?id=${projectToUse.id}`} passHref>
+                <a>
+                    <Button text="View More Info" addClassName='block mt-2'/>
+                </a>
+            </Link> */}
+        </div>
+    )
+}
+
+export default ApplicationCard

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -16,6 +16,10 @@ const ApplicationCard = ({ app, isOutgoing }) => {
     const onAction = async (response) => {
         // build payload to update application document
         const payload = {open: false, response: response}
+        // handle case of re-opened application
+        if (response === 'Pending') {
+            payload.open = true
+        }
         // update Firebase document
         await updateDoc('applications', app.id, payload)
         // handle case of approved application
@@ -24,14 +28,14 @@ const ApplicationCard = ({ app, isOutgoing }) => {
         }
         const updatedApp = appToUse
         updatedApp.response = response
-        updatedApp.open = false
+        updatedApp.open = payload.open
         setAppToUse(updatedApp)
     }
 
     return (
         <div className='p-2 w-full h-full border-2 border-gray-400 rounded-md'>
             <div className='w-full'>
-                <p className='text-xl font-medium'>{app.project.name}</p>
+                <p className='text-xl font-medium'>{appToUse.project.name}</p>
             </div>
             <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
             <div className='pt-2'>
@@ -39,24 +43,29 @@ const ApplicationCard = ({ app, isOutgoing }) => {
                     isOutgoing ?
                         <div>
                             Project Owner:{'  '}
-                            <UserIcon username={app.owner.username} />
+                            <UserIcon username={appToUse.owner.username} />
                         </div>
                     :
                         <div>
                             Applicant:{'  '}
-                            <UserIcon username={app.user.username}/>
+                            <UserIcon username={appToUse.user.username}/>
                         </div>
                 }
             </div>
             <div className='pt-2'>
-                Response: {app.response}
+                Response: {appToUse.response}
             </div>
             <div className='pt-2'>
-                Status: {app.open ? 'Open' : 'Closed'}
+                Status: {appToUse.open ? 'Open' : 'Closed'}
             </div>
             <div className='pt-8'>
                 {
-                    !app.open ?
+                    !appToUse.open && appToUse.response === 'Cancelled' ?
+                    <div>
+                        <Button text='Re-Open Application' type='btnGeneral' onClick={() => onAction('Pending')}/>
+                    </div>
+                    :
+                    !appToUse.open ?
                     <div></div>
                     :
                     isOutgoing ?

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -14,6 +14,7 @@ const ApplicationCard = ({ app, isOutgoing }) => {
     const [appToUse, setAppToUse] = useState(app)
 
     const onAction = async (response) => {
+        console.log('appToUse at beginning of onAction: ', appToUse)                // **** DEBUG DELETE ME ****
         // build payload to update application document
         const payload = {open: false, response: response}
         // handle case of re-opened application
@@ -21,15 +22,18 @@ const ApplicationCard = ({ app, isOutgoing }) => {
             payload.open = true
         }
         // update Firebase document
-        await updateDoc('applications', app.id, payload)
+        await updateDoc('applications', appToUse.id, payload)
         // handle case of approved application
         if (response === 'Approved') {
-            await createAssociation('projects_users', app.project_id, app.user_id)
+            await createAssociation('projects_users', appToUse.project_id, appToUse.user_id)
         }
         const updatedApp = appToUse
-        updatedApp.response = response
+        updatedApp.response = payload.response
         updatedApp.open = payload.open
+        console.log('appToUse: ', appToUse)
+        console.log('updatedApp:', updatedApp)
         setAppToUse(updatedApp)
+        console.log('appToUse: ', appToUse)
     }
 
     return (

--- a/portfolio-project-matching-app/components/ApplicationCard.js
+++ b/portfolio-project-matching-app/components/ApplicationCard.js
@@ -1,64 +1,63 @@
 // library
 // component
 import Button from '../components/Button'
+import UserIcon from '../components/UserIcon'
 
 
 const ApplicationCard = ({ app, isOutgoing }) => {
+
+    const onCancel = () => {
+        // todo
+    }
+
+    const onApprove = () => {
+        // todo
+    }
+
+    const onReject = () => {
+        // todo
+    }
+
     return (
         <div className='p-2 w-full h-full border-2 border-gray-400 rounded-md'>
             <div className='w-full'>
                 <p className='text-xl font-medium'>{app.project.name}</p>
             </div>
             <hr className='w-11/12 sm:w-9/12 border-b-2 border-gray-400'/>
-            <div>
-                Project Owner: {app.owner.username}
-            </div>
-            <div>
-                <Button text='Cancel Application' type='btnWarning' onClick={() => {}}/>
-            </div>
-            {/* <div className='flex flex-wrap'>
-                {projectToUse.technologies.map((technology) => {
-                    return (
-                        <div key={technology.id} className='py-1 pr-2'>
-                            <Button text={technology.name}/>
+            <div className='pt-2'>
+                {
+                    isOutgoing ?
+                        <div>
+                            Project Owner:{'  '}
+                            <UserIcon username={app.owner.username} />
                         </div>
-                )
-                })}
+                    :
+                        <div>
+                            Applicant:{'  '}
+                            <UserIcon username={app.user.username}/>
+                        </div>
+                }
             </div>
-            <div className=''>
-                <p className='line-clamp-3 lg:line-clamp-2 xl:line-clamp-1'>
-                    {projectToUse.description}
-                </p>
+            <div className='pt-2'>
+                Response: {app.response}
             </div>
-            <div className='mt-2 flex flex-wrap'>
-                <div className='self-center'>
-                    {projectToUse.census} out of {projectToUse.capacity} ({projectToUse.capacity - projectToUse.census} positions left)
+            <div className='pt-8'>
+                {
+                    isOutgoing ?
+                    <div>
+                        <Button text='Cancel Application' type='btnWarning' onClick={onCancel}/>
                     </div>
-                <div className='p-1'>
-                    <Button text='join' onClick={applyToProject} type='btnGeneral' />
-                </div>
-            </div>
-            <div className='flex flex-wrap'>
-                Commented out, but leaving in just in case we decide to add this back
-                {project.users.map((user) => {
-                    return (
-                    <div key={user.id} className='py-1 pr-2'>
-                        <UserIcon imgPath='/../public/user.ico' username={user.username} />
+                    :
+                    <div>
+                        <div className='inline pr-2'>
+                            <Button text='Approve' type='btnGeneral' onClick={onApprove}/>
+                        </div>
+                        <div className='inline'>
+                            <Button text='Reject' type='btnWarning' onClick={onReject}/>
+                        </div>
                     </div>
-                    )
-                })}
+                }
             </div>
-            <div className='inline'>
-                <h3 className='py-1 inline'>{projectToUse.likes} Likes</h3>
-                <div className='p-1 inline'>
-                    <Button text='Like' onClick={likeProject} type='btnGeneral' />
-                </div>
-            </div>
-            <Link href={`/project?id=${projectToUse.id}`} passHref>
-                <a>
-                    <Button text="View More Info" addClassName='block mt-2'/>
-                </a>
-            </Link> */}
         </div>
     )
 }

--- a/portfolio-project-matching-app/components/ProjectCard.js
+++ b/portfolio-project-matching-app/components/ProjectCard.js
@@ -2,7 +2,7 @@
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
 // backend
-import { createAssociation, getProjectById } from '../backend/dao.js'
+import { createAssociation, createApplication } from '../backend/dao.js'
 // component
 import Button from '../components/Button'
 // import UserIcon from '../components/UserIcon'
@@ -29,15 +29,13 @@ const ProjectCard = ({ project }) => {
         }
         // handle case where user is logged in
         else {
-            const docSnap = await createAssociation('projects_users', project.id, authUser.user.id)
+            const docSnap = await createApplication(project.id, authUser.user.id)
             // handle case where user is already added to project
             if (docSnap === -1) {
-                alert(`You have already joined that project`)
+                alert(`Error creating application -- tidy up this log later`)
             }
-            // handle case where user is added to project
-            else {
-                setProjectToUse(await getProjectById(project.id))
-            }
+            // raise alert to indicate successful application
+            alert(`Application '${docSnap.id}' created successfully. See application in My Profile -> My Applications`)
         }
     }
 

--- a/portfolio-project-matching-app/models/Application.js
+++ b/portfolio-project-matching-app/models/Application.js
@@ -1,0 +1,60 @@
+class Application {
+    // fields
+    id;
+    projectId;
+    userId;
+    ownerId;
+    open;
+    response;
+    project;
+    user;
+    owner;
+
+    // static factory methods (used like overloaded constructors)
+    static fromDocSnapshot(id, docSnapshot) {
+        /*
+        DESCRIPTION:    takes document ID and document snapshot and creates
+                        corresponding Application object
+
+        INPUT:          document ID in string format and application document
+                        snapshot
+
+        RETURN:         Application object with fields populated. Note,
+                        project, user, and owner properties will remain null
+        */
+        // instantiate new Project object
+        const application = new Application();
+        // set fields/properties based on provided id and snapshot
+        application.id = id;
+        application.projectId = docSnapshot.data().project_id;
+        application.userId = docSnapshot.data().user_id;
+        application.ownerId = docSnapshot.data().owner_id;
+        application.open = docSnapshot.data().open;
+        application.response = docSnapshot.data().response;
+        // return to user
+        return application;
+    }
+
+    // static fromObject(map) {
+    //     /*
+    //     DESCRIPTION:    takes map of project related data and creates a Project
+    //                     object with similar fields
+
+    //     INPUT:          map of project data with keys mirroring fields in
+    //                     Firebase project documents
+
+    //     RETURN:         Project object with fields populated. Note, any keys
+    //                     that do not exist in the map will be left null in the
+    //                     returned Project object
+    //     */
+    //     // instantiate new Project object
+    //     const project = new Project();
+    //     // set fields/properties based on provided id and snapshot
+    //     if (map.id) project.id = map.id;
+    //     if (map.name) project.name = map.name;
+    //     // return to user
+    //     return project;
+    // }
+}
+
+export { Application }

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -22,6 +22,7 @@ const myApplications = () => {
     const [isOutgoing, setIsOutgoing] = useState(true)
 
     useEffect(() => {
+        console.log('myApplications useEffect() called') //                                 **** DEBUG DELETE ME ****
         // tracks whether component mounted, cleanup will assign false
         let isMounted = true
         // handle case where user is NOT logged in

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -58,14 +58,22 @@ const myApplications = () => {
                     // if outGoing is set, show outgoing applications
                     <div className=''>
                         {outApplications.map((app) => {
-                            return <ApplicationCard key={app.id} app={app} isOutgoing={isOutgoing}/>
+                            return (
+                                <div key={app.id} className='p-2'>
+                                    <ApplicationCard app={app} isOutgoing={isOutgoing}/>
+                                </div>
+                            )
                         })}
                     </div>
                 :
                     // if outGoing is clear, show incoming applications
                     <div>
                         {inApplications.map((app) => {
-                            return <ApplicationCard key={app.id} app={app} isOutgoing={isOutgoing}/>
+                            return (
+                                <div key={app.id} className='p-2'>
+                                    <ApplicationCard app={app} isOutgoing={isOutgoing}/>
+                                </div>
+                            )
                         })}
                     </div>
             }

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -1,0 +1,12 @@
+// library
+import { useState, useEffect } from 'react'
+
+const myApplications = () => {
+    return (
+        <div>
+            
+        </div>
+    )
+}
+
+export default myApplications

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -1,10 +1,50 @@
 // library
 import { useState, useEffect } from 'react'
+// backend
+import { readApplicationsById } from '../backend/dao.js';
+// component
+import ApplicationCard from '../components/ApplicationCard'
+// context
+import { useAuth } from '../context/AuthContext'
 
 const myApplications = () => {
+    // array harboring incoming applications
+    const [inApplications, setInApplications] = useState([])
+
+    // array harboring outgoing applications
+    const [outApplications, setOutApplications] = useState([])
+
+    // get auth'd user
+    let authUser = useAuth()
+
+    useEffect(() => {
+        // tracks whether component mounted, cleanup will assign false
+        let isMounted = true
+        // handle case where user is NOT logged in
+        console.log(authUser);
+        console.log(authUser.user.id);
+        if (!authUser.user) {
+            alert('must be logged in to view this page')
+        }
+        // get outgoing applications and set statge
+        readApplicationsById('user_id', authUser.user.id).then((apps) => {
+            if (isMounted) setOutApplications(apps)
+        })
+        // get incoming applications and set stgatge
+        readApplicationsById('owner_id', authUser.user.id).then((apps) => {
+            if (isMounted) setInApplications(apps)
+        })
+        // cleanup function to assign false to isMounted
+        return function cleanup() {
+            isMounted = false
+        }
+    }, [])
+
     return (
         <div>
-            
+            {outApplications.map((app) => {
+                return <ApplicationCard key={app.id} app={app}/>
+            })}
         </div>
     )
 }

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { readApplicationsById } from '../backend/dao.js';
 // component
 import ApplicationCard from '../components/ApplicationCard'
+import Button from '../components/Button'
 // context
 import { useAuth } from '../context/AuthContext'
 
@@ -13,6 +14,9 @@ const myApplications = () => {
 
     // array harboring outgoing applications
     const [outApplications, setOutApplications] = useState([])
+
+    // determines whether incoming or outgoing applications are displayed
+    const [isOutgoing, setIsOutgoing] = useState(true)
 
     // get auth'd user
     let authUser = useAuth()
@@ -40,11 +44,31 @@ const myApplications = () => {
         }
     }, [])
 
+    const toggleOutgoing = () => {
+        setIsOutgoing(isOutgoing ? false : true)
+    }
+
     return (
-        <div>
-            {outApplications.map((app) => {
-                return <ApplicationCard key={app.id} app={app}/>
-            })}
+        <div className='p-2'>
+            <div className='pb-2'>
+                <Button text={isOutgoing ? 'Show Incoming' : 'Show Outgoing'} type='btnGeneral' onClick={toggleOutgoing}/>
+            </div>
+            {
+                isOutgoing ?
+                    // if outGoing is set, show outgoing applications
+                    <div className=''>
+                        {outApplications.map((app) => {
+                            return <ApplicationCard key={app.id} app={app} isOutgoing={isOutgoing}/>
+                        })}
+                    </div>
+                :
+                    // if outGoing is clear, show incoming applications
+                    <div>
+                        {inApplications.map((app) => {
+                            return <ApplicationCard key={app.id} app={app} isOutgoing={isOutgoing}/>
+                        })}
+                    </div>
+            }
         </div>
     )
 }

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -1,7 +1,7 @@
 // library
 import { useState, useEffect } from 'react'
 // backend
-import { readApplicationsById } from '../backend/dao.js';
+import { readApplicationsById, readApplicationIdsById, readDocIdsByCriteria } from '../backend/dao.js';
 // component
 import ApplicationCard from '../components/ApplicationCard'
 import Button from '../components/Button'
@@ -29,12 +29,12 @@ const myApplications = () => {
             alert('must be logged in to view this page')
         }
         // get outgoing applications and set statge
-        readApplicationsById('user_id', authUser.user.id).then((apps) => {
-            if (isMounted) setOutApplications(apps.map(app => app.id))
+        readDocIdsByCriteria('applications', 'user_id', authUser.user.id).then((appIds) => {
+            if (isMounted) setOutApplications(appIds)
         })
         // get incoming applications and set stgatge
-        readApplicationsById('owner_id', authUser.user.id).then((apps) => {
-            if (isMounted) setInApplications(apps.map(app => app.id))
+        readDocIdsByCriteria('applications', 'owner_id', authUser.user.id).then((appIds) => {
+            if (isMounted) setInApplications(appIds)
         })
         // cleanup function to assign false to isMounted
         return function cleanup() {

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -9,6 +9,9 @@ import Button from '../components/Button'
 import { useAuth } from '../context/AuthContext'
 
 const myApplications = () => {
+    // get auth'd user
+    let authUser = useAuth()
+
     // array harboring incoming applications
     const [inApplications, setInApplications] = useState([])
 
@@ -17,9 +20,6 @@ const myApplications = () => {
 
     // determines whether incoming or outgoing applications are displayed
     const [isOutgoing, setIsOutgoing] = useState(true)
-
-    // get auth'd user
-    let authUser = useAuth()
 
     useEffect(() => {
         // tracks whether component mounted, cleanup will assign false

--- a/portfolio-project-matching-app/pages/myApplications.js
+++ b/portfolio-project-matching-app/pages/myApplications.js
@@ -22,22 +22,19 @@ const myApplications = () => {
     const [isOutgoing, setIsOutgoing] = useState(true)
 
     useEffect(() => {
-        console.log('myApplications useEffect() called') //                                 **** DEBUG DELETE ME ****
         // tracks whether component mounted, cleanup will assign false
         let isMounted = true
         // handle case where user is NOT logged in
-        console.log(authUser);
-        console.log(authUser.user.id);
         if (!authUser.user) {
             alert('must be logged in to view this page')
         }
         // get outgoing applications and set statge
         readApplicationsById('user_id', authUser.user.id).then((apps) => {
-            if (isMounted) setOutApplications(apps)
+            if (isMounted) setOutApplications(apps.map(app => app.id))
         })
         // get incoming applications and set stgatge
         readApplicationsById('owner_id', authUser.user.id).then((apps) => {
-            if (isMounted) setInApplications(apps)
+            if (isMounted) setInApplications(apps.map(app => app.id))
         })
         // cleanup function to assign false to isMounted
         return function cleanup() {
@@ -60,8 +57,8 @@ const myApplications = () => {
                     <div className=''>
                         {outApplications.map((app) => {
                             return (
-                                <div key={app.id} className='p-2'>
-                                    <ApplicationCard app={app} isOutgoing={isOutgoing}/>
+                                <div key={app} className='p-2'>
+                                    <ApplicationCard appId={app} isOutgoing={isOutgoing}/>
                                 </div>
                             )
                         })}
@@ -71,8 +68,8 @@ const myApplications = () => {
                     <div>
                         {inApplications.map((app) => {
                             return (
-                                <div key={app.id} className='p-2'>
-                                    <ApplicationCard app={app} isOutgoing={isOutgoing}/>
+                                <div key={app} className='p-2'>
+                                    <ApplicationCard appId={app} isOutgoing={isOutgoing}/>
                                 </div>
                             )
                         })}

--- a/portfolio-project-matching-app/pages/myProfile.js
+++ b/portfolio-project-matching-app/pages/myProfile.js
@@ -14,6 +14,12 @@ const myProfile = () => {
                     <Button text="My Projects" isLink={true} addClassName="bg-white m-2"/>
                     </a>
                 </Link>
+                <Link href="/myApplications" passHref>
+                    {/* Link's child must take an href, so Button must be wrapped with <a> tags */}
+                    <a>
+                    <Button text="My Applications" isLink={true} addClassName="bg-white m-2"/>
+                    </a>
+                </Link>
                 <ProfileForm />
             </div>
     )

--- a/portfolio-project-matching-app/pages/test_dao.js
+++ b/portfolio-project-matching-app/pages/test_dao.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import {
+    createApplication,
     createAssociation,
     createDoc,
     createNewLike,
@@ -15,6 +16,7 @@ import {
     deleteUserDoc,
     getProjectById,
     readAllDocs,
+    readApplicationsById,
     updateDoc,
     updateProject,
 } from '../backend/dao'
@@ -96,11 +98,20 @@ const test_createProject = () => {
         // const userId = 'PdJa7Nq3LJCbEOFxA2Vj';
         // await createAssociation('projects_users', projectId, userId);
 
-        const projectId = '8DubXEKajkhmy7l3sRdV';
-        const userId = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
-        await deleteAssociation('projects_users', projectId, userId); 
+        // const projectId = '8DubXEKajkhmy7l3sRdV';
+        // const userId = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
+        // await deleteAssociation('projects_users', projectId, userId); 
 
+        // const projectId = '6AqEuYkqrsArfuUEIOCQ';
+        // const userId = '0ko4TWBnkjPdpqqnbdCTnjMmROB2';
+        // await createApplication(projectId, userId);
 
+        // await deleteDoc('applications', '6AqEuYkqrsArfuUEIOCQ_0ko4TWBnkjPdpqqnbdCTnjMmROB2');
+
+        const field = 'user_id';
+        const id = '0ko4TWBnkjPdpqqnbdCTnjMmROB2';
+        const apps = await readApplicationsById(field, id);
+        console.log('apps: ', apps);
 
     }
 

--- a/portfolio-project-matching-app/pages/test_dao.js
+++ b/portfolio-project-matching-app/pages/test_dao.js
@@ -102,14 +102,14 @@ const test_createProject = () => {
         // const userId = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
         // await deleteAssociation('projects_users', projectId, userId); 
 
-        // const projectId = '6AqEuYkqrsArfuUEIOCQ';
-        // const userId = '0ko4TWBnkjPdpqqnbdCTnjMmROB2';
+        // const projectId = 'lvaaHKqTrt4QWr3rbEXI';
+        // const userId = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
         // await createApplication(projectId, userId);
 
         // await deleteDoc('applications', '6AqEuYkqrsArfuUEIOCQ_0ko4TWBnkjPdpqqnbdCTnjMmROB2');
 
         const field = 'user_id';
-        const id = '0ko4TWBnkjPdpqqnbdCTnjMmROB2';
+        const id = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
         const apps = await readApplicationsById(field, id);
         console.log('apps: ', apps);
 

--- a/portfolio-project-matching-app/pages/test_dao.js
+++ b/portfolio-project-matching-app/pages/test_dao.js
@@ -17,6 +17,7 @@ import {
     getProjectById,
     readAllDocs,
     readApplicationsById,
+    readDocIdsByCriteria,
     updateDoc,
     updateProject,
 } from '../backend/dao'
@@ -108,10 +109,17 @@ const test_createProject = () => {
 
         // await deleteDoc('applications', '6AqEuYkqrsArfuUEIOCQ_0ko4TWBnkjPdpqqnbdCTnjMmROB2');
 
-        const field = 'user_id';
-        const id = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
-        const apps = await readApplicationsById(field, id);
-        console.log('apps: ', apps);
+        // const field = 'user_id';
+        // const id = '8Ro56x6vPshn2E5XFI2CNfZH5Kg1';
+        // const apps = await readApplicationsById(field, id);
+        // console.log('apps: ', apps);
+
+        // const coll = 'dummy';
+        // const field = 'dummy';
+        // const criteria = 'dummy';
+        // const ids = await readDocIdsByCriteria(coll, field, criteria);
+        // console.log('ids: ', ids);
+
 
     }
 


### PR DESCRIPTION
Created `myApplications` page and some of the infrastructure required to make that happen:
- built `createApplication()` and `readApplicationsById()` in `dao.js`
- built a very basic `ApplicationCard` component to assist in displaying applications
- user can toggle between incoming and outgoing applications via button
- depending on whether application is outgoing or incoming, they can approve, reject, or cancel an application
- integrated `ProjectCard` join button to create application
- **fair warning**: If you're developing anything on `myApplications` and you hot-restart, you can expect the app to forget your auth information. If you jump back to `myProfile` you should be able to carry your auth information back into `myApplications`. Seems to be fine outside of changing code and hot-restarting.
- Cancelling an outgoing application will update the Firebase application document response and open flag. The user will not be able to re-apply to the project, but they may re-open their application from their `myApplications` page.
- Rejecting an application will update the application document response and open flag. The user will not be able to re-apply to the project.
- Approving an application updates the Firebase document AND creates an association document in the `projects_users` collection.
- `myApplications` is simply responsible for gathering the applicable application `id` to be passed to the individual `ApplicationCard`s. This appears to improve some of the loading woes we are experiencing in `browseProjects`.

When viewing incoming applications
![image](https://user-images.githubusercontent.com/59572911/141692326-f39324ee-b090-4e59-9b92-c461a71636d7.png)


When viewing outgoing appliations
![image](https://user-images.githubusercontent.com/59572911/141692315-937478fb-58bd-4445-85b7-f5edcb27ebb0.png)

