### PR TITLE
Enhancement `MultiInputDropDown` Icons

### DIFF
--- a/portfolio-project-matching-app/components/MultipleInputDropdown.js
+++ b/portfolio-project-matching-app/components/MultipleInputDropdown.js
@@ -14,14 +14,26 @@ const MultipleInputDropdown = ({options, onChange, name}) => {
     const customStyles = {
       multiValueLabel: (base) => ({
         ...base,
-        border: '1px solid #9f7aea',
-        borderRadius: '0.375rem',
+        // backgroundColor: '#e9d8a6',
+        borderLeft: '1px solid #005f73',
+        borderTop: '1px solid #005f73',
+        borderBottom: '1px solid #005f73',
+        borderTopLeftRadius: '0.375rem',
+        borderBottomLeftRadius: '0.375rem',
       }),
       multiValueRemove: (base) => ({
         ...base,
-        backgroundColor: 'white',
-        border: `1px solid red`,
-        borderRadius: '0.375rem',
+        // backgroundColor: '#e9d8a6',
+        color: '#ae2012',
+        borderRight: `1px solid #005f73`,
+        borderTop: `1px solid #005f73`,
+        borderBottom: `1px solid #005f73`,
+        borderTopRightRadius: '0.375rem',
+        borderBottomRightRadius: '0.375rem',
+        ':hover': {
+          backgroundColor: '#ae2012',
+          color: 'white',
+        },
         
       }),
     }


### PR DESCRIPTION
Switched around the styling a bit:
- Only left border radius on the top left and bottom left for the `MultiValueLabel` and the top right and bottom right for the `MultiValueRemove`.
- Got rid of the border in the middle of `MultiValueLabel` and `MultiValueRemove`.
- The `MultiValueRemove` should highlight with our custom red on hover.

![image](https://user-images.githubusercontent.com/59572911/143768838-bca25524-f010-4cb0-b43b-3f94d55c9713.png)

Demonstrating the `MultiValueRemove` onHover (ignore the poor quality and lack of cursor, I had to use a print screen).
![image](https://user-images.githubusercontent.com/59572911/143768980-f5525776-ac8c-447b-ba3e-69ce6bd814d7.png)

